### PR TITLE
🐛 Correct query building to work with comments

### DIFF
--- a/scripts/overpass-relation.php
+++ b/scripts/overpass-relation.php
@@ -38,7 +38,6 @@ function get(string $city): string
     $query = file_get_contents(
         sprintf('cities/%s/overpass/relation-full-json', $city)
     );
-    $query = str_replace(["\r", "\n"], '', $query);
 
     $client = new \GuzzleHttp\Client();
     $response = $client->request(

--- a/scripts/overpass-way.php
+++ b/scripts/overpass-way.php
@@ -38,7 +38,6 @@ function get(string $city): string
     $query = file_get_contents(
         sprintf('cities/%s/overpass/way-full-json', $city)
     );
-    $query = str_replace(["\r", "\n"], '', $query);
 
     $client = new \GuzzleHttp\Client();
     $response = $client->request(


### PR DESCRIPTION
Hello 🙌

I was wondering how the data where looking for my city, so i've try to setup this, 
but struggled a bit to set it up...

Seems that template overpass queries include comments; 

like this 
```
/**
 * Get all the highway ways in Brussels Region.
 * Filter out bus stops and service highways.
 */
[out:json][timeout:300];
( area["admin_level"=""]["wikidata"=""]; )->.a; // Set "admin_level" and "wikidata" to the correct information of your city
(
    way["highway"]["name"]["highway"!="bus_stop"]["highway"!="elevator"]["highway"!="platform"]["highway"!="service"](area.a);
    way["place"="square"]["name"](area.a);
);
out body;
>;
out skel qt;
```

but in the process, we remove, the \r leading to a query looking lik this 

```
/** * Get all the relevant relations in Brussels Region. */[out:json][timeout:300];( area["admin_level"="8"]["wikidata"="Q497572"]; )->.a; // Set "admin_level" and "wikidata" to the correct information of your city(    relation["type"="associatedStreet"](area.a);    relation["type"="street"](area.a);    relation["type"="multipolygon"]["place"]["name"](area.a);    relation["type"="multipolygon"]["highway"]["name"](area.a););out body;>;out skel qt;
```

and thus the real query is commented.... leading to 0 data beeing downloaded.

As we do a url_encode, i don't really see the point of replacing the returns ...


FTR i'm on OS X