### PR TITLE
🐛 Fix boundary overwriting URL parameters

### DIFF
--- a/resources/map.ts
+++ b/resources/map.ts
@@ -16,6 +16,8 @@ export let map: Map;
 
 mapboxgl.accessToken = process.env.MAPBOX_TOKEN;
 
+var initialLocation = location.hash
+
 export default async function (): Promise<Map> {
   // Initialize map.
   map = new Map({
@@ -31,7 +33,9 @@ export default async function (): Promise<Map> {
     const boundary = await response.json();
     const boundingBox = turfBBox(turfFeature(boundary.geometries[0]));
 
-    map.fitBounds(boundingBox as LngLatBoundsLike, { padding: 25 });
+    if(!initialLocation) {
+      map.fitBounds(boundingBox as LngLatBoundsLike, { padding: 25 });
+    }
   }
 
   // Add controls.


### PR DESCRIPTION
Attempts to fix #160.
I believe this should work now, when entering an URL without location (like `index.html`) it still fits the bounds to the boundary file, and when an URL with a location (like `index.html#17.43/52.992668/6.570612`) is entered it will just use that.