### PR TITLE
Report errors during build process

### DIFF
--- a/global/build.js
+++ b/global/build.js
@@ -7,8 +7,15 @@ const turf = require('@turf/turf');
 const version = require('./package.json').version;
 
 program.version(version);
+
 program.option('-s, --serve').action(bundle);
-program.parse(process.argv);
+
+program
+  .parseAsync(process.argv)
+  .catch(error => {
+    shell.echo(`Error: ${error}`);
+    shell.exit(1);
+  });
 
 async function bundle (options) {
   const serve = options.serve || false;

--- a/website/build.js
+++ b/website/build.js
@@ -14,7 +14,10 @@ program.version(version);
 
 program.option('-c, --city <path>').option('-s, --serve').action(bundle);
 
-program.parse(process.argv);
+program.parseAsync(process.argv).catch(error => {
+  console.error(error);
+  process.exit(1);
+});
 
 async function bundle (options) {
   const city = options.city;

--- a/website/build.js
+++ b/website/build.js
@@ -14,10 +14,12 @@ program.version(version);
 
 program.option('-c, --city <path>').option('-s, --serve').action(bundle);
 
-program.parseAsync(process.argv).catch(error => {
-  console.error(error);
-  process.exit(1);
-});
+program
+  .parseAsync(process.argv)
+  .catch(error => {
+    shell.echo(`Error: ${error}`);
+    shell.exit(1);
+  });
 
 async function bundle (options) {
   const city = options.city;


### PR DESCRIPTION
When an error occurs during the build process, the Node.js process might exit with code 0 because async rejections are not handled.

This recently occured here: https://github.com/EqualStreetNames/equalstreetnames-stgallen/runs/2589858766
In this case, `npm run build:..` should have reported exit code 1 to abort the workflow and notify the user.