### PR TITLE
Check exit code in build.js

### DIFF
--- a/website/build.js
+++ b/website/build.js
@@ -55,7 +55,10 @@ async function bundle (options) {
     if (serve === true) {
       shell.exec(`parcel serve "${file}" --dist-dir "${outDir}"`, { async: true });
     } else {
-      shell.exec(`parcel build "${file}" --dist-dir "${outDir}"`);
+      if (shell.exec(`parcel build "${file}" --dist-dir "${outDir}"`).code !== 0) {
+        shell.echo(`Error: Build failed`);
+        shell.exit(1);
+      }
     }
   } else {
     shell.echo(`Error: Path ${directory} does not exist.`);


### PR DESCRIPTION
Since the [GItHub build actions](https://github.com/EqualStreetNames/equalstreetnames/pull/336/checks?check_run_id=3648822050#step:5:9) currently succeed, even though the Parcel build is failing, it might be worth checking the exit code of the build in `build.js`. This would probably also prevent GItHub Pages being down if a build fails like in #302.